### PR TITLE
bugfix(core): rename Components to components

### DIFF
--- a/modules/@ergonode/core/src/components/Grid/Layout/Collection/Cells/GridCollectionCell.vue
+++ b/modules/@ergonode/core/src/components/Grid/Layout/Collection/Cells/GridCollectionCell.vue
@@ -32,7 +32,7 @@ export default {
     },
     computed: {
         collectionCellComponent() {
-            const extendedComponents = this.$getExtendedComponents('@Core/Components/Grid/Layout/Collection/Cells');
+            const extendedComponents = this.$getExtendedComponents('@Core/components/Grid/Layout/Collection/Cells');
 
             if (extendedComponents && extendedComponents[this.data.type]) {
                 return extendedComponents[this.data.type];

--- a/modules/@ergonode/core/src/components/Grid/Layout/Table/Cells/Data/GridDataCell.vue
+++ b/modules/@ergonode/core/src/components/Grid/Layout/Table/Cells/Data/GridDataCell.vue
@@ -73,7 +73,7 @@ export default {
     },
     computed: {
         dataCellComponent() {
-            const extendedComponents = this.$getExtendedComponents('@Core/Components/Grid/Layout/Table/Cells/Data');
+            const extendedComponents = this.$getExtendedComponents('@Core/components/Grid/Layout/Table/Cells/Data');
 
             if (extendedComponents && extendedComponents[this.column.type]) {
                 return extendedComponents[this.column.type];

--- a/modules/@ergonode/core/src/components/Grid/Layout/Table/GridTableLayout.vue
+++ b/modules/@ergonode/core/src/components/Grid/Layout/Table/GridTableLayout.vue
@@ -538,7 +538,7 @@ export default {
                 orderedColumns.push(column);
                 columnWidths.push(column.width || COLUMN_WIDTH.DEFAULT);
 
-                const extendedComponents = this.$getExtendedComponents('@Core/Components/Grid/Layout/Table/Columns');
+                const extendedComponents = this.$getExtendedComponents('@Core/components/Grid/Layout/Table/Columns');
 
                 if (extendedComponents && extendedComponents[column.type]) {
                     this.extendedColumns[column.id] = extendedComponents[column.type];

--- a/modules/@ergonode/core/src/components/ProgressList/ProgressList.vue
+++ b/modules/@ergonode/core/src/components/ProgressList/ProgressList.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import ComplexProgressBar from '@Core/Components/ProgressBar/Complex/ComplexProgressBar';
+import ComplexProgressBar from '@Core/components/ProgressBar/Complex/ComplexProgressBar';
 
 export default {
     name: 'ProgressList',

--- a/modules/@ergonode/media/src/config/extends.js
+++ b/modules/@ergonode/media/src/config/extends.js
@@ -9,10 +9,10 @@ import {
 
 export default {
     extendComponents: {
-        '@Core/Components/Grid/Layout/Table/Cells/Data': {
+        '@Core/components/Grid/Layout/Table/Cells/Data': {
             MEDIA_ATTACH: Components.GridMediaAttachDataCell,
         },
-        '@Core/Components/Grid/Layout/Collection/Cells': {
+        '@Core/components/Grid/Layout/Collection/Cells': {
             MEDIA_ATTACH: Components.GridMediaAttachCollectionCell,
         },
     },

--- a/modules/@ergonode/products/src/config/extends.js
+++ b/modules/@ergonode/products/src/config/extends.js
@@ -15,7 +15,7 @@ export default {
         },
     ],
     extendComponents: {
-        '@Core/Components/Grid/Layout/Table/Cells/Data': {
+        '@Core/components/Grid/Layout/Table/Cells/Data': {
             PRODUCT_ATTACH: Components.GridProductAttachDataCell,
         },
     },

--- a/modules/@ergonode/users/src/config/extends.js
+++ b/modules/@ergonode/users/src/config/extends.js
@@ -15,10 +15,10 @@ export default {
         },
     ],
     extendComponents: {
-        '@Core/Components/Grid/Layout/Table/Cells/Data': {
+        '@Core/components/Grid/Layout/Table/Cells/Data': {
             PRIVILEGE_NAME_HINT: Components.GridPrivilegeNameHintDataCell,
         },
-        '@Core/Components/Grid/Layout/Table/Columns': {
+        '@Core/components/Grid/Layout/Table/Columns': {
             PRIVILEGE_ROW_CHECK: Components.GridPrivilegeRowCheckColumn,
             LANGUAGE_ROW_CHECK: Components.GridLanguageRowCheckColumn,
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

Rename `Components` to `components` in import component