### PR TITLE
Fetch user after language inheritance tree update

### DIFF
--- a/modules/@ergonode/core/src/components/Tabs/LanguagesSettingsTab.vue
+++ b/modules/@ergonode/core/src/components/Tabs/LanguagesSettingsTab.vue
@@ -152,6 +152,9 @@ export default {
             'setDefaultLanguage',
             'updateLanguageTree',
         ]),
+        ...mapActions('authentication', [
+            'getUser',
+        ]),
         onSubmit() {
             if (this.isSubmitting) {
                 return;
@@ -173,8 +176,21 @@ export default {
                 });
             }
         },
-        onUpdateSuccess(languages) {
+        async onUpdateSuccess(languages) {
             this.setLanguageTree(languages);
+
+            await this.getUser({
+                onSuccess: this.onGetUserSuccess,
+            });
+        },
+        onUpdateError(message) {
+            this.$addAlert({
+                type: ALERT_TYPE.ERROR,
+                message,
+            });
+            this.isSubmitting = false;
+        },
+        onGetUserSuccess() {
             this.setDefaultLanguage();
 
             this.$addAlert({
@@ -184,13 +200,6 @@ export default {
             this.isSubmitting = false;
 
             this.markChangeValuesAsSaved(this.scope);
-        },
-        onUpdateError(message) {
-            this.$addAlert({
-                type: ALERT_TYPE.ERROR,
-                message,
-            });
-            this.isSubmitting = false;
         },
     },
 };


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

When user has updated language inheritance tree, it wasn't fetching current logged user once again, which is necessary to 
fetch current `languagePrivileges`. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
