### PR TITLE
Add support for single select column row

### DIFF
--- a/modules/@ergonode/ui/src/components/CheckBox/CheckBox.vue
+++ b/modules/@ergonode/ui/src/components/CheckBox/CheckBox.vue
@@ -124,9 +124,8 @@ export default {
         display: grid;
         grid-template-columns: max-content;
         grid-auto-flow: column;
-        column-gap: 8px;
+        column-gap: 4px;
         align-items: center;
-        margin: 4px;
 
         & label {
             position: relative;
@@ -135,6 +134,7 @@ export default {
 
             &::after {
                 position: absolute;
+                left: 4px;
                 width: 16px;
                 height: 16px;
                 box-shadow: $ELEVATOR_HOVER_FOCUS;
@@ -155,6 +155,7 @@ export default {
             width: 16px;
             height: 16px;
             border: $BORDER_1_GREY;
+            margin: 4px;
             box-sizing: border-box;
             background-color: $WHITE;
         }

--- a/modules/@ergonode/ui/src/components/Grid/Grid.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Grid.vue
@@ -58,6 +58,7 @@
                         :extended-components="extendedComponents[gridLayout.TABLE]"
                         :selected-rows="selectedRows"
                         :excluded-from-selection-rows="excludedFromSelectionRows"
+                        :multiselect="multiselect"
                         :is-prefetching-data="isPrefetchingData"
                         :is-layout-resolved="isLayoutResolved[layout]"
                         :is-editable="isEditable"
@@ -89,6 +90,7 @@
                         :extended-components="extendedComponents[gridLayout.COLLECTION]"
                         :selected-rows="selectedRows"
                         :excluded-from-selection-rows="excludedFromSelectionRows"
+                        :multiselect="multiselect"
                         :is-selected-all="isSelectedAll"
                         :is-select-column="isSelectColumn"
                         :is-editable="isEditable"
@@ -263,6 +265,13 @@ export default {
         draggingElementType: {
             type: String,
             default: DRAGGED_ELEMENT.LIST,
+        },
+        /**
+         * Determines if the component is multiple choice
+         */
+        multiselect: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Determines if data is loaded asynchronously
@@ -450,13 +459,21 @@ export default {
             isSelected,
             rowIds,
         }) {
-            rowIds.forEach((rowId) => {
-                this.selectedRows[rowId] = isSelected;
-            });
+            let selectedRows = {};
 
-            this.selectedRows = {
-                ...this.selectedRows,
-            };
+            if (this.multiselect) {
+                selectedRows = {
+                    ...this.selectedRows,
+                };
+
+                rowIds.forEach((rowId) => {
+                    selectedRows[rowId] = isSelected;
+                });
+            } else {
+                selectedRows[rowIds[0]] = isSelected;
+            }
+
+            this.selectedRows = selectedRows;
         },
         onExcludedRowsSelect({
             isExcluded,

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Collection/Cells/GridCollectionCell.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Collection/Cells/GridCollectionCell.vue
@@ -8,6 +8,7 @@
         :data="data"
         :drafts="drafts"
         :object-fit="objectFit"
+        :multiselect="multiselect"
         :locked="locked"
         :selected="selectedRowState"
         :is-select-column="isSelectColumn"
@@ -69,6 +70,13 @@ export default {
         excludedFromSelectionRows: {
             type: Object,
             default: () => ({}),
+        },
+        /**
+         * Determines if the component is multiple choice
+         */
+        multiselect: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Determines if every row should be selected

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Collection/Cells/GridCollectionDefaultCell.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Collection/Cells/GridCollectionDefaultCell.vue
@@ -22,11 +22,18 @@
             :title="data.description" />
         <GridCollectionCellActionsPanel>
             <template #prepend>
-                <CheckBox
-                    v-if="isSelectColumn"
-                    class="grid-collection-default-cell__select"
-                    :value="selected"
-                    @input="onSelect" />
+                <template v-if="isSelectColumn">
+                    <div
+                        class="grid-collection-default-cell__select"
+                        @click.prevent="onSelect">
+                        <CheckBox
+                            v-if="multiselect"
+                            :value="selected" />
+                        <RadioButton
+                            v-else
+                            :value="selected" />
+                    </div>
+                </template>
             </template>
             <template #append>
                 <Fab
@@ -72,10 +79,12 @@ import IconDelete from '@UI/components/Icons/Actions/IconDelete';
 import IconEdit from '@UI/components/Icons/Actions/IconEdit';
 import IconPreview from '@UI/components/Icons/Actions/IconPreview';
 import LazyImage from '@UI/components/LazyImage/LazyImage';
+import RadioButton from '@UI/components/RadioButton/RadioButton';
 
 export default {
     name: 'GridCollectionDefaultCell',
     components: {
+        RadioButton,
         GridCollectionCellActionsPanel,
         IconPreview,
         IconDelete,
@@ -106,6 +115,13 @@ export default {
         objectFit: {
             type: String,
             default: '',
+        },
+        /**
+         * Determines if the component is multiple choice
+         */
+        multiselect: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Determines if component is selected
@@ -220,6 +236,11 @@ export default {
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;
+        }
+
+        &__select {
+            padding: 6px;
+            cursor: pointer;
         }
 
         &__image {

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Collection/GridCollectionLayout.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Collection/GridCollectionLayout.vue
@@ -7,7 +7,7 @@
         <Preloader v-if="isPrefetchingData || !isLayoutResolved" />
         <template v-else>
             <div
-                v-if="isSelectColumn"
+                v-if="isSelectColumn && multiselect"
                 class="grid-collection-layout__header">
                 <GridSelectCollectionHeaderCell
                     :row-ids="rowIds"
@@ -29,6 +29,7 @@
                     :object-fit="objectFit"
                     :locked="!isEditable"
                     :selected-rows="selectedRows"
+                    :multiselect="multiselect"
                     :excluded-from-selection-rows="excludedFromSelectionRows"
                     :extended-data-cell="extendedComponents.dataCells
                         && extendedComponents.dataCells[element.type]"
@@ -130,6 +131,13 @@ export default {
         extendedComponents: {
             type: Object,
             default: () => ({}),
+        },
+        /**
+         * Determines if the component is multiple choice
+         */
+        multiselect: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Determines if selecting row column is visible

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/Cells/Edit/GridMultiSelectRowEditCell.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/Cells/Edit/GridMultiSelectRowEditCell.vue
@@ -12,21 +12,21 @@
         :disabled="disabled"
         @mousedown.native="onSelect"
         @edit="onSelect">
-        <GridRadioEditCell
+        <GridCheckEditCell
             :value="selected"
             :disabled="disabled" />
     </GridTableCell>
 </template>
 
 <script>
-import GridRadioEditCell from '@UI/components/Grid/Layout/Table/Cells/Edit/GridRadioEditCell';
+import GridCheckEditCell from '@UI/components/Grid/Layout/Table/Cells/Edit/GridCheckEditCell';
 import GridTableCell from '@UI/components/Grid/Layout/Table/Cells/GridTableCell';
 
 export default {
-    name: 'GridSelectRowEditCell',
+    name: 'GridMultiSelectRowEditCell',
     components: {
-        GridRadioEditCell,
         GridTableCell,
+        GridCheckEditCell,
     },
     props: {
         /**

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/Cells/Edit/GridRadioEditCell.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/Cells/Edit/GridRadioEditCell.vue
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Ergonode Sp. z o.o. All rights reserved.
+ * See LICENSE for license details.
+ */
+<template>
+    <RadioButton
+        @click.native.prevent
+        :value="value"
+        :disabled="disabled" />
+</template>
+
+<script>
+
+import RadioButton from '@UI/components/RadioButton/RadioButton';
+
+export default {
+    name: 'GridRadioEditCell',
+    components: {
+        RadioButton,
+    },
+    props: {
+        /**
+         * Component value
+         */
+        value: {
+            type: [
+                Boolean,
+                Number,
+            ],
+            default: false,
+        },
+        /**
+         * Determinate if the component is disabled
+         */
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+    .radio-button {
+        padding: 3px;
+    }
+</style>

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/Columns/GridMultiSelectRowColumn.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/Columns/GridMultiSelectRowColumn.vue
@@ -1,0 +1,199 @@
+/*
+ * Copyright © Ergonode Sp. z o.o. All rights reserved.
+ * See LICENSE for license details.
+ */
+<template>
+    <GridActionColumn>
+        <template #header>
+            <GridSelectRowHeaderCell
+                :rows-offset="rowsOffset"
+                :row-ids="rowIds"
+                :selected-rows="selectedRows"
+                :excluded-from-selection-rows="excludedFromSelectionRows"
+                :disabled="!isAnyData"
+                :is-selected-all="isSelectedAll"
+                @excluded-rows-select="onExcludedRowsSelect"
+                @rows-select="onRowsSelect" />
+        </template>
+        <GridTableCell
+            v-if="isBasicFilter"
+            :locked="true"
+            :row="rowsOffset + 1"
+            :column="0">
+            <GridSelectRowActionFabCell
+                :disabled="!isAnyData"
+                @select-all-global="onSelectAllGlobal"
+                @select-all-on-this-page="onSelectAllOnThisPage"
+                @deselect-all-global="onDeselectAllGlobal"
+                @deselect-all-on-this-page="onDeselectAllOnThisPage" />
+        </GridTableCell>
+        <GridMultiSelectRowEditCell
+            v-for="(row, rowIndex) in dataCount"
+            :key="row"
+            :column="0"
+            :disabled="disabledRows[rowIds[rowIndex]]"
+            :row="rowsOffset + row + basicFiltersOffset"
+            :row-id="rowIds[rowIndex]"
+            :selected="getSelectedRowState(rowIndex)"
+            @select="onSelectRow" />
+    </GridActionColumn>
+</template>
+
+<script>
+import {
+    deepClone,
+} from '@Core/models/objectWrapper';
+import GridMultiSelectRowEditCell from '@UI/components/Grid/Layout/Table/Cells/Edit/GridMultiSelectRowEditCell';
+import GridSelectRowActionFabCell from '@UI/components/Grid/Layout/Table/Cells/GridSelectRowActionFabCell';
+import GridTableCell from '@UI/components/Grid/Layout/Table/Cells/GridTableCell';
+import GridSelectRowHeaderCell from '@UI/components/Grid/Layout/Table/Cells/Header/GridSelectRowHeaderCell';
+import GridActionColumn from '@UI/components/Grid/Layout/Table/Columns/GridActionColumn';
+
+export default {
+    name: 'GridMultiSelectRowColumn',
+    components: {
+        GridSelectRowHeaderCell,
+        GridActionColumn,
+        GridTableCell,
+        GridMultiSelectRowEditCell,
+        GridSelectRowActionFabCell,
+    },
+    props: {
+        /**
+         * Column index of given component at the loop
+         */
+        columnIndex: {
+            type: Number,
+            required: true,
+        },
+        /**
+         * Number of visible data
+         */
+        dataCount: {
+            type: Number,
+            default: 0,
+        },
+        /**
+         * List of row ids
+         */
+        rowIds: {
+            type: Array,
+            default: () => [],
+        },
+        /**
+         * The disabled rows are defining which rows are not being able to interact with
+         */
+        disabledRows: {
+            type: Object,
+            default: () => ({}),
+        },
+        /**
+         * The map of selected rows
+         */
+        selectedRows: {
+            type: Object,
+            default: () => ({}),
+        },
+        /**
+         * The map of rows excluded from selection
+         */
+        excludedFromSelectionRows: {
+            type: Object,
+            default: () => ({}),
+        },
+        /**
+         * The number from which rows are enumerated
+         */
+        rowsOffset: {
+            type: Number,
+            default: 0,
+        },
+        /**
+         * Determines if filters are visible
+         */
+        isBasicFilter: {
+            type: Boolean,
+            default: false,
+        },
+        /**
+         * Determines if every row should be selected
+         */
+        isSelectedAll: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    computed: {
+        isAnyData() {
+            return this.dataCount > 0;
+        },
+        basicFiltersOffset() {
+            return this.isBasicFilter ? 1 : 0;
+        },
+    },
+    methods: {
+        onSelectAllGlobal() {
+            this.$emit('select-all', true);
+        },
+        onSelectAllOnThisPage() {
+            if (this.isSelectedAll) {
+                this.$emit('excluded-rows-select', {
+                    isExcluded: false,
+                    rowIds: deepClone(this.rowIds),
+                });
+            } else {
+                this.$emit('rows-select', {
+                    isSelected: true,
+                    rowIds: deepClone(this.rowIds),
+                });
+            }
+        },
+        onDeselectAllGlobal() {
+            this.$emit('select-all', false);
+        },
+        onDeselectAllOnThisPage() {
+            if (this.isSelectedAll) {
+                this.$emit('excluded-rows-select', {
+                    isExcluded: true,
+                    rowIds: deepClone(this.rowIds),
+                });
+            } else {
+                this.$emit('rows-select', {
+                    isSelected: false,
+                    rowIds: deepClone(this.rowIds),
+                });
+            }
+        },
+        onExcludedRowsSelect(payload) {
+            this.$emit('excluded-rows-select', payload);
+        },
+        onRowsSelect(payload) {
+            this.$emit('rows-select', payload);
+        },
+        onSelectRow({
+            row,
+            selected,
+        }) {
+            if (this.isSelectedAll) {
+                this.$emit('excluded-rows-select', {
+                    isExcluded: !selected,
+                    rowIds: [
+                        row,
+                    ],
+                });
+            } else {
+                this.$emit('rows-select', {
+                    isSelected: selected,
+                    rowIds: [
+                        row,
+                    ],
+                });
+            }
+        },
+        getSelectedRowState(index) {
+            return this.selectedRows[this.rowIds[index]]
+                || (this.isSelectedAll && !this.excludedFromSelectionRows[this.rowIds[index]]);
+        },
+    },
+};
+</script>

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/Columns/GridSelectRowColumn.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/Columns/GridSelectRowColumn.vue
@@ -5,28 +5,16 @@
 <template>
     <GridActionColumn>
         <template #header>
-            <GridSelectRowHeaderCell
-                :rows-offset="rowsOffset"
-                :row-ids="rowIds"
-                :selected-rows="selectedRows"
-                :excluded-from-selection-rows="excludedFromSelectionRows"
-                :disabled="!isAnyData"
-                :is-selected-all="isSelectedAll"
-                @excluded-rows-select="onExcludedRowsSelect"
-                @rows-select="onRowsSelect" />
+            <GridTableCell
+                :locked="true"
+                :row="rowsOffset"
+                :column="0" />
         </template>
         <GridTableCell
             v-if="isBasicFilter"
             :locked="true"
             :row="rowsOffset + 1"
-            :column="0">
-            <GridSelectRowActionFabCell
-                :disabled="!isAnyData"
-                @select-all-global="onSelectAllGlobal"
-                @select-all-on-this-page="onSelectAllOnThisPage"
-                @deselect-all-global="onDeselectAllGlobal"
-                @deselect-all-on-this-page="onDeselectAllOnThisPage" />
-        </GridTableCell>
+            :column="0" />
         <GridSelectRowEditCell
             v-for="(row, rowIndex) in dataCount"
             :key="row"
@@ -34,29 +22,22 @@
             :disabled="disabledRows[rowIds[rowIndex]]"
             :row="rowsOffset + row + basicFiltersOffset"
             :row-id="rowIds[rowIndex]"
-            :selected="getSelectedRowState(rowIndex)"
+            :selected="selectedRows[rowIds[rowIndex]]"
             @select="onSelectRow" />
     </GridActionColumn>
 </template>
 
 <script>
-import {
-    deepClone,
-} from '@Core/models/objectWrapper';
 import GridSelectRowEditCell from '@UI/components/Grid/Layout/Table/Cells/Edit/GridSelectRowEditCell';
-import GridSelectRowActionFabCell from '@UI/components/Grid/Layout/Table/Cells/GridSelectRowActionFabCell';
 import GridTableCell from '@UI/components/Grid/Layout/Table/Cells/GridTableCell';
-import GridSelectRowHeaderCell from '@UI/components/Grid/Layout/Table/Cells/Header/GridSelectRowHeaderCell';
 import GridActionColumn from '@UI/components/Grid/Layout/Table/Columns/GridActionColumn';
 
 export default {
     name: 'GridSelectRowColumn',
     components: {
-        GridSelectRowHeaderCell,
         GridActionColumn,
         GridTableCell,
         GridSelectRowEditCell,
-        GridSelectRowActionFabCell,
     },
     props: {
         /**
@@ -95,13 +76,6 @@ export default {
             default: () => ({}),
         },
         /**
-         * The map of rows excluded from selection
-         */
-        excludedFromSelectionRows: {
-            type: Object,
-            default: () => ({}),
-        },
-        /**
          * The number from which rows are enumerated
          */
         rowsOffset: {
@@ -115,13 +89,6 @@ export default {
             type: Boolean,
             default: false,
         },
-        /**
-         * Determines if every row should be selected
-         */
-        isSelectedAll: {
-            type: Boolean,
-            default: false,
-        },
     },
     computed: {
         isAnyData() {
@@ -132,41 +99,6 @@ export default {
         },
     },
     methods: {
-        onSelectAllGlobal() {
-            this.$emit('select-all', true);
-        },
-        onSelectAllOnThisPage() {
-            if (this.isSelectedAll) {
-                this.$emit('excluded-rows-select', {
-                    isExcluded: false,
-                    rowIds: deepClone(this.rowIds),
-                });
-            } else {
-                this.$emit('rows-select', {
-                    isSelected: true,
-                    rowIds: deepClone(this.rowIds),
-                });
-            }
-        },
-        onDeselectAllGlobal() {
-            this.$emit('select-all', false);
-        },
-        onDeselectAllOnThisPage() {
-            if (this.isSelectedAll) {
-                this.$emit('excluded-rows-select', {
-                    isExcluded: true,
-                    rowIds: deepClone(this.rowIds),
-                });
-            } else {
-                this.$emit('rows-select', {
-                    isSelected: false,
-                    rowIds: deepClone(this.rowIds),
-                });
-            }
-        },
-        onExcludedRowsSelect(payload) {
-            this.$emit('excluded-rows-select', payload);
-        },
         onRowsSelect(payload) {
             this.$emit('rows-select', payload);
         },
@@ -174,25 +106,12 @@ export default {
             row,
             selected,
         }) {
-            if (this.isSelectedAll) {
-                this.$emit('excluded-rows-select', {
-                    isExcluded: !selected,
-                    rowIds: [
-                        row,
-                    ],
-                });
-            } else {
-                this.$emit('rows-select', {
-                    isSelected: selected,
-                    rowIds: [
-                        row,
-                    ],
-                });
-            }
-        },
-        getSelectedRowState(index) {
-            return this.selectedRows[this.rowIds[index]]
-                || (this.isSelectedAll && !this.excludedFromSelectionRows[this.rowIds[index]]);
+            this.$emit('rows-select', {
+                isSelected: selected,
+                rowIds: [
+                    row,
+                ],
+            });
         },
     },
 };

--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/GridTableLayout.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/GridTableLayout.vue
@@ -14,7 +14,8 @@
                 v-if="isSelectColumn"
                 :pinned-state="pinnedState.LEFT"
                 :sections="pinnedSections">
-                <GridSelectRowColumn
+                <GridMultiSelectRowColumn
+                    v-if="multiselect"
                     :style="templateRows"
                     :column-index="0"
                     :data-count="dataCount"
@@ -28,6 +29,17 @@
                     @rows-select="onRowsSelect"
                     @excluded-rows-select="onExcludedRowsSelect"
                     @select-all="onSelectAllRows" />
+                <GridSelectRowColumn
+                    v-else
+                    :style="templateRows"
+                    :column-index="0"
+                    :data-count="dataCount"
+                    :disabled-rows="disabledRows"
+                    :rows-offset="rowsOffset"
+                    :row-ids="rowIds"
+                    :selected-rows="selectedRows"
+                    :is-basic-filter="isBasicFilter"
+                    @rows-select="onRowsSelect" />
             </GridTableLayoutPinnedSection>
             <GridTableLayoutColumnsSection
                 :style="templateColumns"
@@ -165,6 +177,7 @@ import {
 } from '@Core/models/stringWrapper';
 import DropZone from '@UI/components/DropZone/DropZone';
 import GridDraggableDataColumn from '@UI/components/Grid/Layout/Table/Columns/GridDraggableDataColumn';
+import GridMultiSelectRowColumn from '@UI/components/Grid/Layout/Table/Columns/GridMultiSelectRowColumn';
 import GridRowActionColumn from '@UI/components/Grid/Layout/Table/Columns/GridRowActionColumn';
 import GridSelectRowColumn from '@UI/components/Grid/Layout/Table/Columns/GridSelectRowColumn';
 import GridSentinelColumn from '@UI/components/Grid/Layout/Table/Columns/GridSentinelColumn';
@@ -180,13 +193,14 @@ import {
 export default {
     name: 'GridTableLayout',
     components: {
+        GridSelectRowColumn,
         Preloader,
         DropZone,
         GridDraggableDataColumn,
         GridRowActionColumn,
         GridTableLayoutColumnsSection,
         GridTableLayoutPinnedSection,
-        GridSelectRowColumn,
+        GridMultiSelectRowColumn,
         GridSentinelColumn,
     },
     mixins: [
@@ -276,6 +290,13 @@ export default {
         excludedFromSelectionRows: {
             type: Object,
             default: () => ({}),
+        },
+        /**
+         * Determines if the component is multiple choice
+         */
+        multiselect: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Determines if data is loaded asynchronously

--- a/modules/@ergonode/ui/src/components/RadioButton/RadioButton.vue
+++ b/modules/@ergonode/ui/src/components/RadioButton/RadioButton.vue
@@ -43,7 +43,10 @@ export default {
          * Component value
          */
         value: {
-            type: String,
+            type: [
+                String,
+                Boolean,
+            ],
             default: '',
         },
         /**
@@ -70,6 +73,10 @@ export default {
     },
     computed: {
         isSelected() {
+            if (typeof this.value === 'boolean') {
+                return this.value;
+            }
+
             return this.value === this.label;
         },
         radioValue: {
@@ -77,7 +84,7 @@ export default {
                 return this.value;
             },
             set() {
-                this.$emit('input', this.label);
+                this.$emit('input', typeof this.value === 'boolean' ? !this.value : this.label);
             },
         },
         classes() {
@@ -101,7 +108,7 @@ export default {
         display: grid;
         grid-template-columns: max-content;
         grid-auto-flow: column;
-        column-gap: 8px;
+        column-gap: 4px;
         align-items: center;
 
         & input[type="radio"] {
@@ -134,6 +141,7 @@ export default {
             width: 18px;
             height: 18px;
             border: $BORDER_1_GREY;
+            margin: 4px;
             box-sizing: border-box;
             cursor: pointer;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

Grid has now `multiselect` prop with default value `true`. When flag is set to `false` instead of having manu choice row selection, the only single row would be possibile to select. 

Issue #968 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
