### PR TITLE
Extending grid columns

### DIFF
--- a/modules/@ergonode/ui/src/components/Grid/Layout/Table/GridTableLayout.vue
+++ b/modules/@ergonode/ui/src/components/Grid/Layout/Table/GridTableLayout.vue
@@ -624,40 +624,40 @@ export default {
                 } = column;
 
                 if (typeof this.extendedComponents.columns[type] !== 'undefined') {
+                    this.columnTypes[type] = this.getColumnTypeName(column);
+
                     requests.push(this.setExtendedColumn(type));
-                } else {
-                    if (typeof this.columnTypes[type] === 'undefined') {
-                        this.columnTypes[type] = this.getColumnTypeName(column);
+                } else if (typeof this.columnTypes[type] === 'undefined') {
+                    this.columnTypes[type] = this.getColumnTypeName(column);
 
-                        try {
-                            if (this.extendedComponents.dataCells
+                    try {
+                        if (this.extendedComponents.dataCells
                                 && this.extendedComponents.dataCells[type]) {
-                                requests.push(this.setExtendedDataCell(type));
-                            } else {
-                                requests.push(this.setDataCell(type));
-                            }
-                        } catch (e) {
-                            requests.push(this.setDefaultDataCell(type));
+                            requests.push(this.setExtendedDataCell(type));
+                        } else {
+                            requests.push(this.setDataCell(type));
                         }
+                    } catch (e) {
+                        requests.push(this.setDefaultDataCell(type));
                     }
+                }
 
-                    if (column.filter && typeof this.filterTypes[column.filter.type] === 'undefined') {
-                        const {
-                            type: filterType,
-                        } = column.filter;
+                if (column.filter && typeof this.filterTypes[column.filter.type] === 'undefined') {
+                    const {
+                        type: filterType,
+                    } = column.filter;
 
-                        this.filterTypes[filterType] = this.getColumnFilterTypeName(column);
+                    this.filterTypes[filterType] = this.getColumnFilterTypeName(column);
 
-                        try {
-                            if (this.extendedComponents.dataFilterCells
-                                && this.extendedComponents.dataFilterCells[filterType]) {
-                                requests.push(this.setExtendedFilterDataCell(filterType));
-                            } else {
-                                requests.push(this.setDataFilterCell(filterType));
-                            }
-                        } catch (e) {
-                            requests.push(this.setDefaultDataFilterCell(filterType));
+                    try {
+                        if (this.extendedComponents.dataFilterCells
+                            && this.extendedComponents.dataFilterCells[filterType]) {
+                            requests.push(this.setExtendedFilterDataCell(filterType));
+                        } else {
+                            requests.push(this.setDataFilterCell(filterType));
                         }
+                    } catch (e) {
+                        requests.push(this.setDefaultDataFilterCell(filterType));
                     }
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

Considering 3 columns with filter type: MULTI_SELECT, TEXT, NUMERIC

When module extended filter type MULTI_SELECT by extending column with custom and he wanted to use default SELECT filter already defined by UI then the filter would not be loaded cuz he was overwriting everything by extending Column

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
