### PR TITLE
Improve copy and support for not chosen binding attributes

### DIFF
--- a/modules/@ergonode/products/src/extends/components/Modals/AddBindingAttributesModalForm.vue
+++ b/modules/@ergonode/products/src/extends/components/Modals/AddBindingAttributesModalForm.vue
@@ -85,7 +85,12 @@ export default {
                 return;
             }
 
-            if (!arraysAreEqual(this.localBindings, this.bindings)) {
+            if (!this.localBindings.length && !this.bindings.length) {
+                this.$addAlert({
+                    type: ALERT_TYPE.INFO,
+                    message: this.$t('@Products.productExtend.components.AddBindingAttributesModalForm.infoMessage'),
+                });
+            } else if (!arraysAreEqual(this.localBindings, this.bindings)) {
                 this.isSubmitting = true;
 
                 this.removeScopeErrors(this.scope);

--- a/modules/@ergonode/products/src/locales/en_GB.json
+++ b/modules/@ergonode/products/src/locales/en_GB.json
@@ -165,8 +165,9 @@
         },
         "AddBindingAttributesModalForm": {
           "title": "Add binding attributes",
-          "submitTitle": "ADD ATTRIBUTES",
-          "successMessage": "Attribute bindings added"
+          "submitTitle": "CHOOSE ATTRIBUTES",
+          "successMessage": "Attribute bindings added",
+          "infoMessage": "No binding attributes have been chosen"
         },
         "ProductVariantsTab": {
           "placeholderTitle": "No binding attributes",

--- a/modules/@ergonode/products/src/locales/pl_PL.json
+++ b/modules/@ergonode/products/src/locales/pl_PL.json
@@ -171,8 +171,9 @@
         },
         "AddBindingAttributesModalForm": {
           "title": "Dodaj atrybuty dowiązujące",
-          "submitTitle": "Dodaj atrybuty",
-          "successMessage": "Atrybuty dowiązujące zostały dodane"
+          "submitTitle": "Wybierz atrybuty",
+          "successMessage": "Atrybuty dowiązujące zostały dodane",
+          "infoMessage": "Brak wybranych atrybutów dowiązujących"
         },
         "ProductVariantsTab": {
           "placeholderTitle": "Brak atrybutów dowiązujących",


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

When user will not chose any binding attributes, then inform him that he must add binding first

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
