### PR TITLE
feat(core): add suport for sort order

### DIFF
--- a/modules/@ergonode/product-templates/src/components/Autocompletes/ProductTemplatesAutocomplete.vue
+++ b/modules/@ergonode/product-templates/src/components/Autocompletes/ProductTemplatesAutocomplete.vue
@@ -14,6 +14,7 @@
         :custom-fetch-event="productTemplateCreatedEventName"
         :error-messages="errorMessages"
         :disabled="disabled"
+        :sort-order="sortOrder"
         href="templates/autocomplete"
         @input="onValueChange">
         <template #noDataPlaceholder>
@@ -29,6 +30,9 @@
 </template>
 
 <script>
+import {
+    SORTING_ORDER,
+} from '@Core/defaults/icons';
 import CreateProductTemplateButton from '@Templates/components/Buttons/CreateProductTemplateButton';
 import {
     PRODUCT_TEMPLATE_CREATED_EVENT_NAME,
@@ -80,6 +84,12 @@ export default {
             return {
                 title: this.$t('@Templates.productTemplate._.noTemplate'),
                 subtitle: this.$t('@Templates.productTemplate._.createFirst'),
+            };
+        },
+        sortOrder() {
+            return {
+                order: SORTING_ORDER.ASC,
+                field: 'label',
             };
         },
     },

--- a/modules/@ergonode/ui/src/components/Autocomplete/Autocomplete.vue
+++ b/modules/@ergonode/ui/src/components/Autocomplete/Autocomplete.vue
@@ -244,6 +244,13 @@ export default {
             type: String,
             default: '',
         },
+        /**
+         * The data model of sorted column
+         */
+        sortOrder: {
+            type: Object,
+            default: null,
+        },
     },
     data() {
         return {
@@ -344,12 +351,19 @@ export default {
             try {
                 this.isFetchingData = true;
 
-                const options = await this.$axios.$get(this.href, {
+                const config = {
                     params: {
                         search: this.searchValue,
                         ...this.params,
                     },
-                });
+                };
+
+                if (this.sortOrder) {
+                    config.params.order = this.sortOrder.order;
+                    config.params.field = this.sortOrder.field;
+                }
+
+                const options = await this.$axios.$get(this.href, config);
 
                 if (this.additionalStaticOptions.length) {
                     const lowerCaseSearchValue = this.searchValue.toLowerCase();


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

Add `sordOrder` prop for `Autocomplete`

```
sortOrder: {
   type: Object,
   default: null,
}
```

`sortObject` property must have 2 fields: `order`: `ASC`, `DESC` and `field`: for example `label`

Issue # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
