### PR TITLE
Add missing parsing for extending notification key

### DIFF
--- a/modules/@ergonode/batch-actions/src/config/extends.js
+++ b/modules/@ergonode/batch-actions/src/config/extends.js
@@ -45,7 +45,7 @@ export default {
 
                 const extendedKey = capitalizeAndConcatenationArray([
                     ...name.split('_'),
-                    status,
+                    ...status.split('_'),
                 ]);
 
                 if (extendedComponents[extendedKey]) {


### PR DESCRIPTION
<!--
Thank you for contributing to Ergonode!
Please fill out this description template to help us to process your pull request.
-->
# Description

The extending key was not prepared in correct format:

Instead of MySuperKey
was Mysuper_key

Issue #1061 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] e2e Test

# Checklist:

- [x] I have read the contribution requirements and fulfil them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
